### PR TITLE
Revamp request console UI

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <meta name="theme-color" content="#10271e" />
     <title>Mock Server</title>
-    <link rel="stylesheet" href="style.css?v=20260903-title-alignment" />
+    <link rel="stylesheet" href="style.css?v=20260903-console-revamp" />
 </head>
 <body>
 <main class="app-shell">
@@ -41,9 +41,8 @@
         <section class="request-panel" aria-label="All requests">
             <div class="panel-header">
                 <div class="panel-heading">
-                    <p class="eyebrow">Traffic</p>
                     <div class="panel-title-line">
-                        <h2>Request log</h2>
+                        <h2>Traffic</h2>
                         <span id="requestCount" class="count-display" aria-label="0 requests">000/200</span>
                     </div>
                 </div>
@@ -55,10 +54,18 @@
                     </label>
                     <button id="clearRequestsButton" class="clear-button danger-button" type="button">Clear</button>
                 </div>
+                <p id="clearError" class="clear-error" role="alert" hidden></p>
             </div>
 
             <div class="table-container" aria-live="polite">
                 <table aria-label="Request log">
+                    <thead>
+                      <tr>
+                        <th scope="col">Time</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Request</th>
+                      </tr>
+                    </thead>
                     <tbody id="requestTableBody">
                     <tr>
                         <td colspan="3" class="empty-state">No requests yet</td>
@@ -69,9 +76,8 @@
             <section class="routes-panel" aria-label="Configured routes">
                 <div class="panel-header compact">
                     <div class="panel-heading">
-                        <p class="eyebrow">Registry</p>
                         <div class="panel-title-line">
-                            <h2>Configured routes</h2>
+                            <h2>Registry</h2>
                             <span id="routeCount" class="count-display compact-count" aria-label="Loading routes">—</span>
                         </div>
                     </div>
@@ -91,11 +97,17 @@
         <section class="side-panel" aria-label="Exchange inspector">
             <section class="detail-panel" aria-label="Request and response details">
                 <div class="detail-section">
-                    <div class="detail-label"><span>Request</span><span class="direction-tag">IN</span></div>
+                    <div class="detail-label">
+                        <h2>Request</h2>
+                        <span class="direction-tag">IN</span>
+                    </div>
                     <div id="requestDetails" class="detail-content"></div>
                 </div>
                 <div class="detail-section">
-                    <div class="detail-label"><span>Response</span><span class="direction-tag response-tag">OUT</span></div>
+                    <div class="detail-label">
+                        <h2>Response</h2>
+                        <span class="direction-tag response-tag">OUT</span>
+                    </div>
                     <div id="responseDetails" class="detail-content"></div>
                 </div>
             </section>
@@ -113,7 +125,7 @@
         <dl class="help-dialog-list">
             <div>
                 <dt>Pause / Resume</dt>
-                <dd>Stops adding new requests to the log. The mock server keeps serving traffic. Requests that arrive while paused are not recorded. Resume starts showing new requests again.</dd>
+                <dd>Pauses the live log on this page. The mock server keeps serving traffic. Events that arrive while paused are skipped here and will not appear when you resume.</dd>
             </div>
             <div>
                 <dt>Export HAR</dt>
@@ -126,6 +138,10 @@
             <div>
                 <dt>Filter</dt>
                 <dd>Shows only log entries whose method, path, or status match what you type.</dd>
+            </div>
+            <div>
+                <dt>Keyboard</dt>
+                <dd>Arrow keys move through the traffic log and load Request/Response details. Home and End jump to the first or last visible row. / focuses the filter.</dd>
             </div>
             <div>
                 <dt>Clear</dt>
@@ -156,9 +172,11 @@
     const themeToggleLabel = document.getElementById('themeToggleLabel');
     const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
     const requestTableBody = document.getElementById('requestTableBody');
+    const requestTable = requestTableBody.closest('table');
     const requestDetails = document.getElementById('requestDetails');
     const responseDetails = document.getElementById('responseDetails');
     const clearRequestsButton = document.getElementById('clearRequestsButton');
+    const clearError = document.getElementById('clearError');
     const pauseButton = document.getElementById('pauseButton');
     const pauseButtonLabel = pauseButton.querySelector('.button-label');
     const exportButton = document.getElementById('exportButton');
@@ -242,6 +260,60 @@
         }
     };
 
+    function getDataRows() {
+        return [...requestTableBody.querySelectorAll('tr[data-id]')];
+    }
+
+    function syncRowTabindex() {
+        const rows = getDataRows();
+        let focusTarget = null;
+        for (const row of rows) {
+            const isSelected = selectedId != null && row.dataset.id === String(selectedId);
+            row.tabIndex = -1;
+            row.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+            if (isSelected) {
+                focusTarget = row;
+            }
+        }
+        if (!focusTarget && rows[0]) {
+            focusTarget = rows[0];
+        }
+        if (focusTarget) {
+            focusTarget.tabIndex = 0;
+        }
+        return focusTarget;
+    }
+
+    function selectRow(row, http) {
+        selectedId = http.id;
+        for (const r of requestTableBody.querySelectorAll('tr[data-id]')) {
+            const isSelected = r === row;
+            r.classList.toggle('selected', isSelected);
+            r.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+            r.tabIndex = isSelected ? 0 : -1;
+        }
+        updateDetail(requestDetails, http.request.details || '');
+        updateDetail(responseDetails, http.response.details || '');
+    }
+
+    function selectRowByOffset(currentRow, index) {
+        const rows = getDataRows();
+        if (!rows.length) {
+            return;
+        }
+        const next = rows[Math.max(0, Math.min(index, rows.length - 1))];
+        if (!next) {
+            return;
+        }
+        const http = eventsById.get(Number(next.dataset.id));
+        if (!http) {
+            return;
+        }
+        selectRow(next, http);
+        next.focus();
+        next.scrollIntoView({ block: 'nearest' });
+    }
+
     requestTableBody.addEventListener('click', (e) => {
         const row = e.target.closest('tr');
         if (!row || !row.dataset.id) {
@@ -251,14 +323,66 @@
         const http = eventsById.get(id);
         if (http) {
             selectRow(row, http);
+            row.focus();
         }
     });
 
+    requestTableBody.addEventListener('keydown', (event) => {
+        if (event.target.matches('input, textarea, [contenteditable="true"]')) {
+            return;
+        }
+        const row = event.target.closest('tr[data-id]');
+        if (!row || !requestTableBody.contains(row)) {
+            return;
+        }
+        const rows = getDataRows();
+        const index = rows.indexOf(row);
+        if (index === -1) {
+            return;
+        }
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            selectRowByOffset(row, index + 1);
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            selectRowByOffset(row, index - 1);
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            selectRowByOffset(row, 0);
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            selectRowByOffset(row, rows.length - 1);
+        } else if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            const http = eventsById.get(Number(row.dataset.id));
+            if (http) {
+                selectRow(row, http);
+            }
+        }
+    });
+
+    function hideClearError() {
+        clearError.hidden = true;
+        clearError.textContent = '';
+    }
+
+    function showClearError() {
+        clearError.hidden = false;
+        clearError.textContent = "Couldn’t clear the log — the server didn’t confirm. Try again.";
+    }
+
     clearRequestsButton.addEventListener('click', async () => {
         try {
-            await fetch('clear', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            const res = await fetch('clear', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+            if (!res.ok) {
+                console.error('failed to clear server events', res.status);
+                showClearError();
+                return;
+            }
         } catch (e) {
             console.error('failed to clear server events', e);
+            showClearError();
+            return;
         }
         eventsById.clear();
         eventOrder = [];
@@ -267,6 +391,7 @@
         renderEmptyState();
         updateDetail(requestDetails, '');
         updateDetail(responseDetails, '');
+        hideClearError();
     });
 
     pauseButton.addEventListener('click', () => {
@@ -376,6 +501,7 @@
     }
 
     function renderTable() {
+        const focusWasInTable = requestTable.contains(document.activeElement);
         const visible = eventOrder
             .map((id) => eventsById.get(id))
             .filter(Boolean)
@@ -390,6 +516,8 @@
         for (const http of visible) {
             const row = requestTableBody.insertRow();
             row.dataset.id = String(http.id);
+            row.tabIndex = -1;
+            row.setAttribute('aria-selected', 'false');
             if (selectedId === http.id) {
                 row.classList.add('selected');
             }
@@ -424,15 +552,11 @@
             urlSpan.textContent = ` ${http.request.url}`;
             c2.appendChild(urlSpan);
         }
-    }
 
-    function selectRow(row, http) {
-        selectedId = http.id;
-        for (const r of requestTableBody.getElementsByTagName('tr')) {
-            r.classList.toggle('selected', r === row);
+        const focusTarget = syncRowTabindex();
+        if (focusWasInTable && focusTarget) {
+            focusTarget.focus({ preventScroll: true });
         }
-        updateDetail(requestDetails, http.request.details || '');
-        updateDetail(responseDetails, http.response.details || '');
     }
 
     function updateDetail(element, newContent) {

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <meta name="theme-color" content="#10271e" />
     <title>Mock Server</title>
-    <link rel="stylesheet" href="style.css?v=20260903-title-alignment" />
+    <link rel="stylesheet" href="style.css?v=20260903-console-revamp" />
 </head>
 <body>
 <main class="app-shell">
@@ -41,9 +41,8 @@
         <section class="request-panel" aria-label="All requests">
             <div class="panel-header">
                 <div class="panel-heading">
-                    <p class="eyebrow">Traffic</p>
                     <div class="panel-title-line">
-                        <h2>Request log</h2>
+                        <h2>Traffic</h2>
                         <span id="requestCount" class="count-display" aria-label="0 requests">000/200</span>
                     </div>
                 </div>
@@ -55,10 +54,18 @@
                     </label>
                     <button id="clearRequestsButton" class="clear-button danger-button" type="button">Clear</button>
                 </div>
+                <p id="clearError" class="clear-error" role="alert" hidden></p>
             </div>
 
             <div class="table-container" aria-live="polite">
                 <table aria-label="Request log">
+                    <thead>
+                      <tr>
+                        <th scope="col">Time</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Request</th>
+                      </tr>
+                    </thead>
                     <tbody id="requestTableBody">
                     <tr>
                         <td colspan="3" class="empty-state">No requests yet</td>
@@ -69,9 +76,8 @@
             <section class="routes-panel" aria-label="Configured routes">
                 <div class="panel-header compact">
                     <div class="panel-heading">
-                        <p class="eyebrow">Registry</p>
                         <div class="panel-title-line">
-                            <h2>Configured routes</h2>
+                            <h2>Registry</h2>
                             <span id="routeCount" class="count-display compact-count" aria-label="Loading routes">—</span>
                         </div>
                     </div>
@@ -91,11 +97,17 @@
         <section class="side-panel" aria-label="Exchange inspector">
             <section class="detail-panel" aria-label="Request and response details">
                 <div class="detail-section">
-                    <div class="detail-label"><span>Request</span><span class="direction-tag">IN</span></div>
+                    <div class="detail-label">
+                        <h2>Request</h2>
+                        <span class="direction-tag">IN</span>
+                    </div>
                     <div id="requestDetails" class="detail-content"></div>
                 </div>
                 <div class="detail-section">
-                    <div class="detail-label"><span>Response</span><span class="direction-tag response-tag">OUT</span></div>
+                    <div class="detail-label">
+                        <h2>Response</h2>
+                        <span class="direction-tag response-tag">OUT</span>
+                    </div>
                     <div id="responseDetails" class="detail-content"></div>
                 </div>
             </section>
@@ -113,7 +125,7 @@
         <dl class="help-dialog-list">
             <div>
                 <dt>Pause / Resume</dt>
-                <dd>Stops adding new requests to the log. The mock server keeps serving traffic. Requests that arrive while paused are not recorded. Resume starts showing new requests again.</dd>
+                <dd>Pauses the live log on this page. The mock server keeps serving traffic. Events that arrive while paused are skipped here and will not appear when you resume.</dd>
             </div>
             <div>
                 <dt>Export HAR</dt>
@@ -126,6 +138,10 @@
             <div>
                 <dt>Filter</dt>
                 <dd>Shows only log entries whose method, path, or status match what you type.</dd>
+            </div>
+            <div>
+                <dt>Keyboard</dt>
+                <dd>Arrow keys move through the traffic log and load Request/Response details. Home and End jump to the first or last visible row. / focuses the filter.</dd>
             </div>
             <div>
                 <dt>Clear</dt>
@@ -155,9 +171,11 @@
     const themeToggleLabel = document.getElementById('themeToggleLabel');
     const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
     const requestTableBody = document.getElementById('requestTableBody');
+    const requestTable = requestTableBody.closest('table');
     const requestDetails = document.getElementById('requestDetails');
     const responseDetails = document.getElementById('responseDetails');
     const clearRequestsButton = document.getElementById('clearRequestsButton');
+    const clearError = document.getElementById('clearError');
     const pauseButton = document.getElementById('pauseButton');
     const pauseButtonLabel = pauseButton.querySelector('.button-label');
     const exportButton = document.getElementById('exportButton');
@@ -241,6 +259,60 @@
         }
     };
 
+    function getDataRows() {
+        return [...requestTableBody.querySelectorAll('tr[data-id]')];
+    }
+
+    function syncRowTabindex() {
+        const rows = getDataRows();
+        let focusTarget = null;
+        for (const row of rows) {
+            const isSelected = selectedId != null && row.dataset.id === String(selectedId);
+            row.tabIndex = -1;
+            row.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+            if (isSelected) {
+                focusTarget = row;
+            }
+        }
+        if (!focusTarget && rows[0]) {
+            focusTarget = rows[0];
+        }
+        if (focusTarget) {
+            focusTarget.tabIndex = 0;
+        }
+        return focusTarget;
+    }
+
+    function selectRow(row, http) {
+        selectedId = http.id;
+        for (const r of requestTableBody.querySelectorAll('tr[data-id]')) {
+            const isSelected = r === row;
+            r.classList.toggle('selected', isSelected);
+            r.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+            r.tabIndex = isSelected ? 0 : -1;
+        }
+        updateDetail(requestDetails, http.request.details || '');
+        updateDetail(responseDetails, http.response.details || '');
+    }
+
+    function selectRowByOffset(currentRow, index) {
+        const rows = getDataRows();
+        if (!rows.length) {
+            return;
+        }
+        const next = rows[Math.max(0, Math.min(index, rows.length - 1))];
+        if (!next) {
+            return;
+        }
+        const http = eventsById.get(Number(next.dataset.id));
+        if (!http) {
+            return;
+        }
+        selectRow(next, http);
+        next.focus();
+        next.scrollIntoView({ block: 'nearest' });
+    }
+
     requestTableBody.addEventListener('click', (e) => {
         const row = e.target.closest('tr');
         if (!row || !row.dataset.id) {
@@ -250,14 +322,66 @@
         const http = eventsById.get(id);
         if (http) {
             selectRow(row, http);
+            row.focus();
         }
     });
 
+    requestTableBody.addEventListener('keydown', (event) => {
+        if (event.target.matches('input, textarea, [contenteditable="true"]')) {
+            return;
+        }
+        const row = event.target.closest('tr[data-id]');
+        if (!row || !requestTableBody.contains(row)) {
+            return;
+        }
+        const rows = getDataRows();
+        const index = rows.indexOf(row);
+        if (index === -1) {
+            return;
+        }
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            selectRowByOffset(row, index + 1);
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            selectRowByOffset(row, index - 1);
+        } else if (event.key === 'Home') {
+            event.preventDefault();
+            selectRowByOffset(row, 0);
+        } else if (event.key === 'End') {
+            event.preventDefault();
+            selectRowByOffset(row, rows.length - 1);
+        } else if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            const http = eventsById.get(Number(row.dataset.id));
+            if (http) {
+                selectRow(row, http);
+            }
+        }
+    });
+
+    function hideClearError() {
+        clearError.hidden = true;
+        clearError.textContent = '';
+    }
+
+    function showClearError() {
+        clearError.hidden = false;
+        clearError.textContent = "Couldn’t clear the log — the server didn’t confirm. Try again.";
+    }
+
     clearRequestsButton.addEventListener('click', async () => {
         try {
-            await fetch('clear', { method: 'POST' });
+            const res = await fetch('clear', { method: 'POST' });
+            if (!res.ok) {
+                console.error('failed to clear server events', res.status);
+                showClearError();
+                return;
+            }
         } catch (e) {
             console.error('failed to clear server events', e);
+            showClearError();
+            return;
         }
         eventsById.clear();
         eventOrder = [];
@@ -266,6 +390,7 @@
         renderEmptyState();
         updateDetail(requestDetails, '');
         updateDetail(responseDetails, '');
+        hideClearError();
     });
 
     pauseButton.addEventListener('click', () => {
@@ -375,6 +500,7 @@
     }
 
     function renderTable() {
+        const focusWasInTable = requestTable.contains(document.activeElement);
         const visible = eventOrder
             .map((id) => eventsById.get(id))
             .filter(Boolean)
@@ -389,6 +515,8 @@
         for (const http of visible) {
             const row = requestTableBody.insertRow();
             row.dataset.id = String(http.id);
+            row.tabIndex = -1;
+            row.setAttribute('aria-selected', 'false');
             if (selectedId === http.id) {
                 row.classList.add('selected');
             }
@@ -423,15 +551,11 @@
             urlSpan.textContent = ` ${http.request.url}`;
             c2.appendChild(urlSpan);
         }
-    }
 
-    function selectRow(row, http) {
-        selectedId = http.id;
-        for (const r of requestTableBody.getElementsByTagName('tr')) {
-            r.classList.toggle('selected', r === row);
+        const focusTarget = syncRowTabindex();
+        if (focusWasInTable && focusTarget) {
+            focusTarget.focus({ preventScroll: true });
         }
-        updateDetail(requestDetails, http.request.details || '');
-        updateDetail(responseDetails, http.response.details || '');
     }
 
     function updateDetail(element, newContent) {

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <meta name="theme-color" content="#10271e" />
     <title>Mock Server</title>
-    <link rel="stylesheet" href="style.css?v=20260903-console-revamp" />
+    <link rel="stylesheet" href="style.css?v=20260903-title-alignment" />
 </head>
 <body>
 <main class="app-shell">
@@ -41,8 +41,9 @@
         <section class="request-panel" aria-label="All requests">
             <div class="panel-header">
                 <div class="panel-heading">
+                    <p class="eyebrow">Traffic</p>
                     <div class="panel-title-line">
-                        <h2>Traffic</h2>
+                        <h2>Request log</h2>
                         <span id="requestCount" class="count-display" aria-label="0 requests">000/200</span>
                     </div>
                 </div>
@@ -54,18 +55,10 @@
                     </label>
                     <button id="clearRequestsButton" class="clear-button danger-button" type="button">Clear</button>
                 </div>
-                <p id="clearError" class="clear-error" role="alert" hidden></p>
             </div>
 
             <div class="table-container" aria-live="polite">
                 <table aria-label="Request log">
-                    <thead>
-                      <tr>
-                        <th scope="col">Time</th>
-                        <th scope="col">Status</th>
-                        <th scope="col">Request</th>
-                      </tr>
-                    </thead>
                     <tbody id="requestTableBody">
                     <tr>
                         <td colspan="3" class="empty-state">No requests yet</td>
@@ -76,8 +69,9 @@
             <section class="routes-panel" aria-label="Configured routes">
                 <div class="panel-header compact">
                     <div class="panel-heading">
+                        <p class="eyebrow">Registry</p>
                         <div class="panel-title-line">
-                            <h2>Registry</h2>
+                            <h2>Configured routes</h2>
                             <span id="routeCount" class="count-display compact-count" aria-label="Loading routes">—</span>
                         </div>
                     </div>
@@ -97,17 +91,11 @@
         <section class="side-panel" aria-label="Exchange inspector">
             <section class="detail-panel" aria-label="Request and response details">
                 <div class="detail-section">
-                    <div class="detail-label">
-                        <h2>Request</h2>
-                        <span class="direction-tag">IN</span>
-                    </div>
+                    <div class="detail-label"><span>Request</span><span class="direction-tag">IN</span></div>
                     <div id="requestDetails" class="detail-content"></div>
                 </div>
                 <div class="detail-section">
-                    <div class="detail-label">
-                        <h2>Response</h2>
-                        <span class="direction-tag response-tag">OUT</span>
-                    </div>
+                    <div class="detail-label"><span>Response</span><span class="direction-tag response-tag">OUT</span></div>
                     <div id="responseDetails" class="detail-content"></div>
                 </div>
             </section>
@@ -125,7 +113,7 @@
         <dl class="help-dialog-list">
             <div>
                 <dt>Pause / Resume</dt>
-                <dd>Pauses the live log on this page. The mock server keeps serving traffic. Events that arrive while paused are skipped here and will not appear when you resume.</dd>
+                <dd>Stops adding new requests to the log. The mock server keeps serving traffic. Requests that arrive while paused are not recorded. Resume starts showing new requests again.</dd>
             </div>
             <div>
                 <dt>Export HAR</dt>
@@ -138,10 +126,6 @@
             <div>
                 <dt>Filter</dt>
                 <dd>Shows only log entries whose method, path, or status match what you type.</dd>
-            </div>
-            <div>
-                <dt>Keyboard</dt>
-                <dd>Arrow keys move through the traffic log and load Request/Response details. Home and End jump to the first or last visible row. / focuses the filter.</dd>
             </div>
             <div>
                 <dt>Clear</dt>
@@ -165,17 +149,16 @@
     </div>
 </dialog>
 
-<script>
+<script id="mock-config">
     const MAX_EVENTS = 200;
+    const MOCK_CONFIG = {"version":"dev"};
     const themeToggle = document.getElementById('themeToggle');
     const themeToggleLabel = document.getElementById('themeToggleLabel');
     const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
     const requestTableBody = document.getElementById('requestTableBody');
-    const requestTable = requestTableBody.closest('table');
     const requestDetails = document.getElementById('requestDetails');
     const responseDetails = document.getElementById('responseDetails');
     const clearRequestsButton = document.getElementById('clearRequestsButton');
-    const clearError = document.getElementById('clearError');
     const pauseButton = document.getElementById('pauseButton');
     const pauseButtonLabel = pauseButton.querySelector('.button-label');
     const exportButton = document.getElementById('exportButton');
@@ -259,60 +242,6 @@
         }
     };
 
-    function getDataRows() {
-        return [...requestTableBody.querySelectorAll('tr[data-id]')];
-    }
-
-    function syncRowTabindex() {
-        const rows = getDataRows();
-        let focusTarget = null;
-        for (const row of rows) {
-            const isSelected = selectedId != null && row.dataset.id === String(selectedId);
-            row.tabIndex = -1;
-            row.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-            if (isSelected) {
-                focusTarget = row;
-            }
-        }
-        if (!focusTarget && rows[0]) {
-            focusTarget = rows[0];
-        }
-        if (focusTarget) {
-            focusTarget.tabIndex = 0;
-        }
-        return focusTarget;
-    }
-
-    function selectRow(row, http) {
-        selectedId = http.id;
-        for (const r of requestTableBody.querySelectorAll('tr[data-id]')) {
-            const isSelected = r === row;
-            r.classList.toggle('selected', isSelected);
-            r.setAttribute('aria-selected', isSelected ? 'true' : 'false');
-            r.tabIndex = isSelected ? 0 : -1;
-        }
-        updateDetail(requestDetails, http.request.details || '');
-        updateDetail(responseDetails, http.response.details || '');
-    }
-
-    function selectRowByOffset(currentRow, index) {
-        const rows = getDataRows();
-        if (!rows.length) {
-            return;
-        }
-        const next = rows[Math.max(0, Math.min(index, rows.length - 1))];
-        if (!next) {
-            return;
-        }
-        const http = eventsById.get(Number(next.dataset.id));
-        if (!http) {
-            return;
-        }
-        selectRow(next, http);
-        next.focus();
-        next.scrollIntoView({ block: 'nearest' });
-    }
-
     requestTableBody.addEventListener('click', (e) => {
         const row = e.target.closest('tr');
         if (!row || !row.dataset.id) {
@@ -322,66 +251,14 @@
         const http = eventsById.get(id);
         if (http) {
             selectRow(row, http);
-            row.focus();
         }
     });
-
-    requestTableBody.addEventListener('keydown', (event) => {
-        if (event.target.matches('input, textarea, [contenteditable="true"]')) {
-            return;
-        }
-        const row = event.target.closest('tr[data-id]');
-        if (!row || !requestTableBody.contains(row)) {
-            return;
-        }
-        const rows = getDataRows();
-        const index = rows.indexOf(row);
-        if (index === -1) {
-            return;
-        }
-        if (event.key === 'ArrowDown') {
-            event.preventDefault();
-            selectRowByOffset(row, index + 1);
-        } else if (event.key === 'ArrowUp') {
-            event.preventDefault();
-            selectRowByOffset(row, index - 1);
-        } else if (event.key === 'Home') {
-            event.preventDefault();
-            selectRowByOffset(row, 0);
-        } else if (event.key === 'End') {
-            event.preventDefault();
-            selectRowByOffset(row, rows.length - 1);
-        } else if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            const http = eventsById.get(Number(row.dataset.id));
-            if (http) {
-                selectRow(row, http);
-            }
-        }
-    });
-
-    function hideClearError() {
-        clearError.hidden = true;
-        clearError.textContent = '';
-    }
-
-    function showClearError() {
-        clearError.hidden = false;
-        clearError.textContent = "Couldn’t clear the log — the server didn’t confirm. Try again.";
-    }
 
     clearRequestsButton.addEventListener('click', async () => {
         try {
-            const res = await fetch('clear', { method: 'POST' });
-            if (!res.ok) {
-                console.error('failed to clear server events', res.status);
-                showClearError();
-                return;
-            }
+            await fetch('clear', { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
         } catch (e) {
             console.error('failed to clear server events', e);
-            showClearError();
-            return;
         }
         eventsById.clear();
         eventOrder = [];
@@ -390,7 +267,6 @@
         renderEmptyState();
         updateDetail(requestDetails, '');
         updateDetail(responseDetails, '');
-        hideClearError();
     });
 
     pauseButton.addEventListener('click', () => {
@@ -500,7 +376,6 @@
     }
 
     function renderTable() {
-        const focusWasInTable = requestTable.contains(document.activeElement);
         const visible = eventOrder
             .map((id) => eventsById.get(id))
             .filter(Boolean)
@@ -515,8 +390,6 @@
         for (const http of visible) {
             const row = requestTableBody.insertRow();
             row.dataset.id = String(http.id);
-            row.tabIndex = -1;
-            row.setAttribute('aria-selected', 'false');
             if (selectedId === http.id) {
                 row.classList.add('selected');
             }
@@ -551,11 +424,15 @@
             urlSpan.textContent = ` ${http.request.url}`;
             c2.appendChild(urlSpan);
         }
+    }
 
-        const focusTarget = syncRowTabindex();
-        if (focusWasInTable && focusTarget) {
-            focusTarget.focus({ preventScroll: true });
+    function selectRow(row, http) {
+        selectedId = http.id;
+        for (const r of requestTableBody.getElementsByTagName('tr')) {
+            r.classList.toggle('selected', r === row);
         }
+        updateDetail(requestDetails, http.request.details || '');
+        updateDetail(responseDetails, http.response.details || '');
     }
 
     function updateDetail(element, newContent) {
@@ -618,43 +495,109 @@
         }
     }
 
+    function headerValue(headers, name) {
+        const want = name.toLowerCase();
+        for (const header of headers) {
+            if ((header.name || '').toLowerCase() === want) {
+                return header.value || '';
+            }
+        }
+        return '';
+    }
+
+    function parseHTTPMessage(details) {
+        const text = details || '';
+        let head = text;
+        let body = '';
+        const splitAt = text.indexOf('\n\n');
+        if (splitAt >= 0) {
+            head = text.slice(0, splitAt);
+            body = text.slice(splitAt + 2);
+        }
+        const lines = head.split('\n');
+        const startLine = lines[0] || '';
+        const headers = [];
+        for (let i = 1; i < lines.length; i++) {
+            const colon = lines[i].indexOf(':');
+            if (colon <= 0) {
+                continue;
+            }
+            headers.push({
+                name: lines[i].slice(0, colon).trim(),
+                value: lines[i].slice(colon + 1).trim(),
+            });
+        }
+        return { startLine, headers, body };
+    }
+
+    function httpVersionFromLine(startLine, fallback) {
+        const match = /\bHTTP\/[\d.]+/.exec(startLine || '');
+        return match ? match[0] : fallback;
+    }
+
+    function queryStringFromURL(url) {
+        const qIndex = (url || '').indexOf('?');
+        if (qIndex < 0) {
+            return [];
+        }
+        const params = new URLSearchParams(url.slice(qIndex + 1));
+        const out = [];
+        for (const [name, value] of params.entries()) {
+            out.push({ name, value });
+        }
+        return out;
+    }
+
     function buildHAR(events) {
-        const entries = events.map((http) => ({
-            startedDateTime: new Date().toISOString(),
-            time: 0,
-            request: {
-                method: http.request.method,
-                url: http.request.url,
-                httpVersion: 'HTTP/1.1',
-                cookies: [],
-                headers: [],
-                queryString: [],
-                headersSize: -1,
-                bodySize: -1,
-                postData: http.request.details ? { mimeType: 'text/plain', text: http.request.details } : undefined,
-            },
-            response: {
-                status: http.response.status,
-                statusText: http.response.statusText || '',
-                httpVersion: 'HTTP/1.1',
-                cookies: [],
-                headers: [],
-                content: {
-                    size: (http.response.details || '').length,
-                    mimeType: 'text/plain',
-                    text: http.response.details || '',
+        const entries = events.map((http) => {
+            const req = parseHTTPMessage(http.request.details);
+            const res = parseHTTPMessage(http.response.details);
+            const reqMime = headerValue(req.headers, 'Content-Type') || 'text/plain';
+            const resMime = headerValue(res.headers, 'Content-Type') || 'text/plain';
+            const host = headerValue(req.headers, 'Host');
+            let url = http.request.url || '';
+            if (host && url.startsWith('/')) {
+                url = 'http://' + host + url;
+            }
+            const started = http.request.startedAt || new Date().toISOString();
+            const elapsed = typeof http.response.elapsedMs === 'number' ? http.response.elapsedMs : 0;
+            return {
+                startedDateTime: started,
+                time: elapsed,
+                request: {
+                    method: http.request.method,
+                    url,
+                    httpVersion: httpVersionFromLine(req.startLine, 'HTTP/1.1'),
+                    cookies: [],
+                    headers: req.headers,
+                    queryString: queryStringFromURL(http.request.url),
+                    headersSize: -1,
+                    bodySize: req.body ? req.body.length : 0,
+                    postData: req.body ? { mimeType: reqMime, text: req.body } : undefined,
                 },
-                redirectURL: '',
-                headersSize: -1,
-                bodySize: -1,
-            },
-            cache: {},
-            timings: { send: 0, wait: 0, receive: 0 },
-        }));
+                response: {
+                    status: http.response.status,
+                    statusText: http.response.statusText || '',
+                    httpVersion: httpVersionFromLine(res.startLine, 'HTTP/1.1'),
+                    cookies: [],
+                    headers: res.headers,
+                    content: {
+                        size: res.body.length,
+                        mimeType: resMime,
+                        text: res.body,
+                    },
+                    redirectURL: headerValue(res.headers, 'Location') || '',
+                    headersSize: -1,
+                    bodySize: res.body.length,
+                },
+                cache: {},
+                timings: { send: 0, wait: 0, receive: 0 },
+            };
+        });
         return {
             log: {
                 version: '1.2',
-                creator: { name: 'mock', version: 'dev' },
+                creator: { name: 'mock', version: MOCK_CONFIG.version },
                 entries,
             },
         };

--- a/static/style.css
+++ b/static/style.css
@@ -123,36 +123,36 @@ button:focus-visible {
     width: min(1740px, 100%);
     height: 100%;
     margin: 0 auto;
-    padding: clamp(18px, 2.25vw, 34px);
-    gap: 17px;
+    padding: clamp(12px, 1.8vw, 24px);
+    gap: 12px;
 }
 
 .topbar {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 24px;
-    min-height: 58px;
+    gap: 20px;
+    min-height: 48px;
 }
 
 .brand-lockup {
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 12px;
     min-width: max-content;
 }
 
 .brand-mark {
     position: relative;
     display: grid;
-    grid-template-columns: 9px 20px 9px;
+    grid-template-columns: 7px 16px 7px;
     align-items: center;
-    width: 54px;
-    height: 54px;
-    padding: 8px;
+    width: 42px;
+    height: 42px;
+    padding: 6px;
     overflow: hidden;
     border: 1px solid var(--line-strong);
-    border-radius: 15px;
+    border-radius: 12px;
     background: var(--surface-raised);
     box-shadow: 0 8px 24px rgba(15, 47, 29, 0.13), inset 0 1px color-mix(in srgb, var(--ink) 8%, transparent);
 }
@@ -161,9 +161,9 @@ button:focus-visible {
     position: absolute;
     right: -15px;
     bottom: -16px;
-    width: 40px;
-    height: 40px;
-    border: 9px solid color-mix(in srgb, var(--lantern) 12%, transparent);
+    width: 32px;
+    height: 32px;
+    border: 8px solid color-mix(in srgb, var(--lantern) 12%, transparent);
     border-radius: 50%;
     content: "";
 }
@@ -172,7 +172,7 @@ button:focus-visible {
     position: absolute;
     top: 0;
     left: 0;
-    width: 4px;
+    width: 3px;
     height: 100%;
     background: linear-gradient(var(--jade), var(--moss) 72%, var(--lantern));
     content: "";
@@ -180,17 +180,17 @@ button:focus-visible {
 
 .brand-mark-node {
     z-index: 1;
-    width: 9px;
-    height: 9px;
+    width: 7px;
+    height: 7px;
     border: 2px solid var(--jade);
     border-radius: 50%;
     background: var(--surface-raised);
-    box-shadow: 0 0 0 4px var(--jade-soft);
+    box-shadow: 0 0 0 3px var(--jade-soft);
 }
 
 .brand-mark-node:last-child {
     border-color: var(--lantern);
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--lantern) 12%, transparent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--lantern) 12%, transparent);
 }
 
 .brand-mark-route {
@@ -200,7 +200,7 @@ button:focus-visible {
 }
 
 .eyebrow {
-    margin: 0 0 4px;
+    margin: 0 0 2px;
     color: var(--muted);
     font-family: var(--mono);
     font-size: 0.66rem;
@@ -244,16 +244,17 @@ h2 {
 }
 
 h1 {
-    font-size: clamp(1.6rem, 2.5vw, 2.15rem);
+    font-size: clamp(1.35rem, 2.1vw, 1.85rem);
     font-weight: 720;
     letter-spacing: -0.05em;
     line-height: 1;
 }
 
 h2 {
-    font-size: 1rem;
+    font-size: 1.32rem;
     font-weight: 700;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
 }
 
 .topbar-actions,
@@ -272,8 +273,8 @@ h2 {
     align-items: center;
     justify-content: center;
     gap: 8px;
-    min-height: 38px;
-    padding: 0 13px;
+    min-height: 34px;
+    padding: 0 12px;
     border: 1px solid var(--line-strong);
     border-radius: 8px;
     background: var(--surface-raised);
@@ -334,7 +335,7 @@ h2 {
 }
 
 .icon-button {
-    width: 38px;
+    width: 34px;
     padding: 0;
     border-radius: 50%;
     font-family: var(--mono);
@@ -462,9 +463,10 @@ h2 {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 16px;
-    min-height: 84px;
-    padding: 16px 18px;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    min-height: 54px;
+    padding: 8px 16px;
     border-bottom: 1px solid var(--line);
     background: color-mix(in srgb, var(--surface-2) 55%, var(--surface));
 }
@@ -503,7 +505,7 @@ h2 {
     display: flex;
     align-items: center;
     min-width: min(235px, 28vw);
-    height: 39px;
+    height: 34px;
     border: 1px solid var(--line);
     border-radius: 8px;
     background: var(--surface-2);
@@ -571,9 +573,27 @@ h2 {
     font-size: 0.66rem;
 }
 
+.clear-error {
+    flex: 1 0 100%;
+    margin: 0 -16px -8px;
+    padding: 6px 16px;
+    border-top: 1px solid color-mix(in srgb, var(--copper) 45%, var(--line));
+    background: var(--copper-soft);
+    color: var(--copper);
+    font-size: 0.78rem;
+    font-weight: 650;
+    letter-spacing: 0.01em;
+}
+
+.clear-error:empty,
+.clear-error[hidden],
+.clear-error.hidden {
+    display: none;
+}
+
 .table-container {
     min-height: 0;
-    padding: 4px 0;
+    padding: 0;
     overflow: auto;
     background: var(--surface);
 }
@@ -585,8 +605,24 @@ table {
     table-layout: fixed;
 }
 
+thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 14px;
+    border-bottom: 1px solid var(--line);
+    background: color-mix(in srgb, var(--surface-2) 82%, var(--surface));
+    color: var(--muted);
+    font-family: var(--mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-align: left;
+    text-transform: uppercase;
+}
+
 td {
-    padding: 10px 15px;
+    padding: 7px 14px;
     border-bottom: 1px solid color-mix(in srgb, var(--line) 68%, transparent);
     color: var(--ink);
     vertical-align: middle;
@@ -609,8 +645,10 @@ td.request-cell {
     white-space: nowrap;
 }
 
+th:nth-child(1),
 td:nth-child(1) { width: 86px; }
 
+th:nth-child(2),
 td:nth-child(2) {
     width: 72px;
     font-family: var(--mono);
@@ -619,14 +657,22 @@ td:nth-child(2) {
     white-space: nowrap;
 }
 
+th:nth-child(2) {
+    font-size: 0.62rem;
+    line-height: 1.3;
+}
+
 tbody tr {
     background: transparent;
     transition: background-color 100ms ease, box-shadow 100ms ease;
 }
 
-tbody tr:hover {
-    background: var(--jade-soft);
+tbody tr[data-id] {
     cursor: pointer;
+}
+
+tbody tr[data-id]:hover {
+    background: var(--jade-soft);
 }
 
 tbody tr.selected {
@@ -634,8 +680,18 @@ tbody tr.selected {
     box-shadow: inset 4px 0 0 var(--jade);
 }
 
+tbody tr[data-id]:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--jade) 40%, transparent);
+    outline-offset: -2px;
+    background: var(--jade-soft);
+}
+
+tbody tr.selected:focus-visible {
+    background: color-mix(in srgb, var(--jade) 18%, var(--surface));
+}
+
 .empty-state {
-    height: 150px;
+    height: 110px;
     color: var(--muted);
     text-align: center;
     font-family: var(--mono);
@@ -645,33 +701,33 @@ tbody tr.selected {
 
 #requestTableBody .empty-state {
     position: relative;
-    padding-top: 50px;
+    padding-top: 36px;
     border-bottom: 0;
 }
 
 #requestTableBody .empty-state::before {
     position: absolute;
-    top: calc(50% - 31px);
+    top: calc(50% - 22px);
     left: 50%;
-    width: 56px;
-    height: 18px;
+    width: 40px;
+    height: 12px;
     border-top: 1px solid var(--line-strong);
     border-bottom: 1px solid var(--line-strong);
     content: "";
     transform: translateX(-50%) skewX(-28deg);
-    opacity: 0.75;
+    opacity: 0.55;
 }
 
 #requestTableBody .empty-state::after {
     position: absolute;
-    top: calc(50% - 28px);
+    top: calc(50% - 20px);
     left: 50%;
-    width: 10px;
-    height: 10px;
+    width: 8px;
+    height: 8px;
     border: 2px solid var(--jade);
     border-radius: 50%;
     background: var(--surface);
-    box-shadow: -25px 5px 0 -3px var(--moss), 25px -3px 0 -3px var(--copper);
+    box-shadow: -18px 4px 0 -2px var(--moss), 18px -2px 0 -2px var(--copper);
     content: "";
     transform: translateX(-50%);
 }
@@ -691,7 +747,7 @@ tbody tr.selected {
     display: grid;
     grid-template-rows: auto minmax(0, 1fr);
     min-height: 0;
-    padding: 16px 17px 18px;
+    padding: 10px 16px 14px;
 }
 
 .detail-section + .detail-section {
@@ -702,14 +758,18 @@ tbody tr.selected {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 10px;
     min-height: 28px;
-    margin-bottom: 9px;
-    color: var(--muted);
-    font-family: var(--mono);
-    font-size: 0.65rem;
+    margin-bottom: 8px;
+}
+
+.detail-label h2 {
+    font-size: 1.32rem;
     font-weight: 700;
-    letter-spacing: 0.13em;
-    text-transform: uppercase;
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+    color: var(--ink);
+    text-transform: none;
 }
 
 .direction-tag {
@@ -757,7 +817,7 @@ tbody tr.selected {
 
 .detail-content:empty::before {
     position: absolute;
-    top: calc(50% + 24px);
+    top: calc(50% + 18px);
     left: 50%;
     width: min(17rem, calc(100% - 36px));
     color: var(--screen-muted);
@@ -768,14 +828,14 @@ tbody tr.selected {
 
 .detail-content:empty::after {
     position: absolute;
-    top: calc(50% - 32px);
+    top: calc(50% - 24px);
     left: 50%;
-    width: 52px;
-    height: 52px;
+    width: 36px;
+    height: 36px;
     border: 1px solid rgba(143, 177, 130, 0.20);
     border-radius: 50%;
     background: radial-gradient(circle, #c4cc8e 0 3px, rgba(173, 194, 109, 0.09) 4px, transparent 70%);
-    box-shadow: 0 0 0 12px rgba(101, 149, 96, 0.035);
+    box-shadow: 0 0 0 8px rgba(101, 149, 96, 0.035);
     content: "";
     transform: translate(-50%, -50%);
 }
@@ -788,8 +848,8 @@ tbody tr.selected {
 }
 
 .panel-header.compact {
-    min-height: 66px;
-    padding: 11px 17px;
+    min-height: 46px;
+    padding: 6px 16px;
 }
 
 .panel-header.compact > .panel-heading {
@@ -840,8 +900,8 @@ tbody tr.selected {
     display: flex;
     align-items: center;
     gap: 8px;
-    min-height: 40px;
-    padding: 7px 17px;
+    min-height: 34px;
+    padding: 5px 16px;
     border-bottom: 1px solid color-mix(in srgb, var(--line) 68%, transparent);
     font-size: 0.8rem;
 }
@@ -937,8 +997,9 @@ tbody tr.selected {
     flex-direction: column;
 }
 
-.help-dialog:focus {
-    outline: none;
+.help-dialog:focus-visible {
+    outline: 3px solid color-mix(in srgb, var(--jade) 40%, transparent);
+    outline-offset: 3px;
 }
 
 .help-dialog::backdrop {
@@ -1056,13 +1117,13 @@ tbody tr.selected {
     .topbar-actions { justify-content: flex-end; }
     .button-label { display: none; }
     .theme-toggle,
-    .topbar-actions .clear-button { width: 38px; padding: 0; }
+    .topbar-actions .clear-button { width: 34px; padding: 0; }
     .workspace { grid-template-columns: minmax(350px, 0.82fr) minmax(440px, 1.18fr); }
     .request-panel > .panel-header:not(.compact) { align-items: flex-start; flex-direction: column; }
     .panel-actions,
     .filter-control { width: 100%; }
     .filter-control { min-width: 0; flex: 1; }
-    .route-toggle-button { width: 38px; padding: 0; }
+    .route-toggle-button { width: 34px; padding: 0; }
     .route-toggle-label { display: none; }
 }
 
@@ -1081,14 +1142,16 @@ tbody tr.selected {
 @media (max-width: 640px) {
     .app-shell { gap: 13px; padding: 11px; }
     .topbar { align-items: stretch; flex-direction: column; }
-    .brand-mark { width: 48px; height: 48px; grid-template-columns: 8px 16px 8px; }
+    .brand-mark { width: 40px; height: 40px; grid-template-columns: 7px 14px 7px; }
     .topbar-actions { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
     .theme-toggle,
     .topbar-actions .clear-button { width: 100%; }
-    .panel-header { padding: 14px; }
+    .panel-header { padding: 10px 12px; }
     .side-panel { min-height: 660px; }
-    td { padding-inline: 8px; }
+    td, thead th { padding-inline: 8px; }
+    th:nth-child(1),
     td:nth-child(1) { width: 73px; }
+    th:nth-child(2),
     td:nth-child(2) { width: 53px; }
     [class^="method-"] { min-width: 42px; margin-right: 5px; }
     .routes-list .route-name { display: none; }


### PR DESCRIPTION
Operator-console revamp of the admin UI (`static/index.html`, `static/style.css`). Branched from `master`; does not touch PR #6.

## Visual / layout
- Drop “Request log” / “Configured routes” subtitles
- Counts stay after Traffic and Registry titles
- Larger titles on Traffic, Registry, Request, Response
- Denser chrome; keep moss/jade identity and existing capabilities

## Working / a11y
- Restore Time / Status / Request column headers (sticky thead)
- Keyboard on log rows (roving tabindex, arrows / Home / End / Enter)
- Honest Pause help: paused SSE events are skipped and do not appear on resume
- Help dialog uses `:focus-visible` (no `outline: none` on `:focus`)
- Clear only wipes the client log after `POST /clear` succeeds; visible error otherwise

Keeps SSE, filter, pause, HAR export (master behavior), theme, routes list, help dialog.