### PR TITLE
Add Cloud Agent dev environment setup (Go 1.26)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Cloud Agent environment bootstrap for the `mock` Go project.
+# Idempotent: safe to run repeatedly against cached or partially prepared state.
+set -euo pipefail
+
+# go.mod requires Go 1.26; the base image ships an older toolchain, so install a
+# pinned 1.26 patch release into /usr/local and expose it ahead of any system Go.
+GO_VERSION="1.26.8"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+
+if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION} "; then
+  echo "Installing Go ${GO_VERSION}..."
+  curl -fsSL -o "/tmp/${GO_TARBALL}" "https://go.dev/dl/${GO_TARBALL}"
+  sudo rm -rf /usr/local/go
+  sudo tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+  rm -f "/tmp/${GO_TARBALL}"
+fi
+
+# /usr/local/bin precedes /usr/bin on PATH, so these symlinks make `go` resolve
+# to 1.26 in every shell without editing shell profiles.
+sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go
+sudo ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+go version
+
+# Repository bootstrap: fetch modules, install the binary, and run the suite so
+# a broken environment fails setup instead of surfacing later.
+go mod download
+make build
+go test ./...


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a reproducible Cloud Agent development environment for the `mock` project and verifies the application runs end-to-end.

The base image ships an older Go toolchain (1.22.2), but `go.mod` requires **Go 1.26**. This adds a repository-managed Cursor environment that installs a pinned Go 1.26 release and bootstraps the project.

## Changes

- `.cursor/environment.json` — repo-managed environment (`user: ubuntu`, runs the install script).
- `.cursor/install.sh` — idempotent bootstrap that:
  - Installs Go 1.26.8 into `/usr/local/go` (skipped when already present).
  - Symlinks `go`/`gofmt` into `/usr/local/bin` so `go` resolves to 1.26 in every shell (ahead of the older system Go) without editing shell profiles.
  - Runs `go mod download`, `make build`, and `go test ./...` so a broken environment fails setup early.

## Verification

- `make all` (fmt, vet, test, build) passes on Go 1.26.8; `go test -race ./...` passes.
- Ran the server via `go run . examples/user.http`; exercised endpoints with `curl` (`/users/:id`, rotating `POST /users` → 201/400, query-matched `/names?type=cat|dog`, `/mock/routes`).
- Drove the admin request console UI at `/mock/` in a browser: live request logging, request/response inspection, route registry, and light/dark theme toggle all work.

No application code changes — this only adds environment configuration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47af5504-4421-492f-bd3d-fb12469f59c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47af5504-4421-492f-bd3d-fb12469f59c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

