### PR TITLE
Distinguish selected row color from hover in Traffic panel

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -677,8 +677,8 @@ tbody tr[data-id]:hover {
 
 tbody tr.selected,
 tbody tr.selected[data-id]:hover {
-    background: color-mix(in srgb, var(--copper) 16%, var(--surface));
-    box-shadow: inset 4px 0 0 var(--copper);
+    background: color-mix(in srgb, var(--jade) 40%, var(--surface));
+    box-shadow: inset 4px 0 0 var(--jade);
 }
 
 tbody tr[data-id]:focus-visible {
@@ -688,7 +688,7 @@ tbody tr[data-id]:focus-visible {
 }
 
 tbody tr.selected:focus-visible {
-    background: color-mix(in srgb, var(--copper) 22%, var(--surface));
+    background: color-mix(in srgb, var(--jade) 46%, var(--surface));
 }
 
 .empty-state {

--- a/static/style.css
+++ b/static/style.css
@@ -675,9 +675,10 @@ tbody tr[data-id]:hover {
     background: var(--jade-soft);
 }
 
-tbody tr.selected {
-    background: color-mix(in srgb, var(--jade) 14%, var(--surface));
-    box-shadow: inset 4px 0 0 var(--jade);
+tbody tr.selected,
+tbody tr.selected[data-id]:hover {
+    background: color-mix(in srgb, var(--copper) 16%, var(--surface));
+    box-shadow: inset 4px 0 0 var(--copper);
 }
 
 tbody tr[data-id]:focus-visible {
@@ -687,7 +688,7 @@ tbody tr[data-id]:focus-visible {
 }
 
 tbody tr.selected:focus-visible {
-    background: color-mix(in srgb, var(--jade) 18%, var(--surface));
+    background: color-mix(in srgb, var(--copper) 22%, var(--surface));
 }
 
 .empty-state {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the web UI's Traffic panel, the selected row and the hovered (highlighted) row used nearly the same faint jade-green background, making it hard to tell which row is selected while moving the mouse. This gives the selected state its own distinct, bolder shade of the same green.

## Changes (`static/style.css`)

- Selected rows now use a **bold/dark jade green** background (`color-mix(--jade 40%, --surface)`) with a solid jade left-accent bar, clearly distinct from the faint jade hover tint (~11%) — same green family, just much bolder.
- Added `tbody tr.selected[data-id]:hover` alongside `tbody tr.selected` so a selected row keeps its bold-green color even while hovered. Previously the `:hover` rule had higher CSS specificity than `.selected`, so hovering the selected row replaced its background with the faint hover color.
- Selected `:focus-visible` uses a slightly deeper jade mix for consistency.

Hover (highlight) remains the subtle jade tint; only the selected color changed.

## Testing

Manual GUI test in the request console with live traffic: verified the selected row is a clearly bolder/darker green than the light hover highlight, in both light and dark themes, including when the selected row itself is hovered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47af5504-4421-492f-bd3d-fb12469f59c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47af5504-4421-492f-bd3d-fb12469f59c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

