### PR TITLE
Document v0.1.2 changelog and bump README version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.1.2 - 2026-09-03
 
+- Gave the selected request row in the Traffic panel its own bolder jade-green
+  background and accent bar so it is clearly distinct from the lighter hover
+  highlight, including when the selected row itself is hovered
 - Removed OpenAPI stub seeding (`-openapi`, `examples/openapi.json`, `examples/openapi.yaml`). Use `.http` files.
 
 ## v0.1.1 - 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,32 @@
 
 ## v0.1.2 - 2026-09-03
 
+Security and correctness hardening, plus further request-console refinements
+after the v0.1.1 redesign.
+
+- Defaulted the bind address to localhost (`127.0.0.1`) and warned when binding
+  all interfaces (`-b 0.0.0.0`), since the admin UI is unauthenticated
+- Limited CORS short-circuiting to genuine browser preflight requests (`OPTIONS`
+  with `Access-Control-Request-Method`); other `OPTIONS` now run the mock route
+- Required `X-Requested-With` or a JSON `Content-Type` on `POST /mock/clear` to
+  guard the admin clear endpoint against cross-site requests
+- Keyed response rotation by route (method, path, and query) so repeated
+  requests rotate through the intended set of responses
+- Made the request-log export produce valid HAR (HTTP Archive) files
+- Ran the Docker image as the unprivileged `nobody` user
+- Added load-time warnings for `.http` dialect issues, such as using a
+  well-known incoming request header as a response header without a matching
+  `$header.*` matcher
+- Reworked the request console into a denser operator layout: request and route
+  counts on the panel titles, larger headings, a sticky table header,
+  keyboard-navigable log rows, clearer Pause help text, and enabling Clear only
+  after the server confirms the log was cleared
+- Removed unused table headers from the request log
 - Gave the selected request row in the Traffic panel its own bolder jade-green
   background and accent bar so it is clearly distinct from the lighter hover
   highlight, including when the selected row itself is hovered
 - Removed OpenAPI stub seeding (`-openapi`, `examples/openapi.json`, `examples/openapi.yaml`). Use `.http` files.
+- Updated the README screenshots to show the current console
 
 ## v0.1.1 - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prism, or Mockoon, and not the Go unit-test mocking libraries (gomock, mockery).
 Requires [Go](https://go.dev/dl/) 1.26 or newer:
 
 ```sh
-go install github.com/sspencer/mock@v0.1.1
+go install github.com/sspencer/mock@v0.1.2
 mock -version
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `v0.1.2` section to `CHANGELOG.md` documenting all relevant changes merged since `v0.1.1`, and bumps the `v0.1.1` reference in the README to `v0.1.2`.

## Changes

`CHANGELOG.md` — new `## v0.1.2 - 2026-09-03` section covering the post-`v0.1.1` work:
- Security/correctness hardening: localhost bind default (+ warning on `0.0.0.0`), CORS preflight-only short-circuiting, CSRF guard on `POST /mock/clear`, route-keyed response rotation, valid HAR export, Docker `nobody` user, and `.http` dialect load-time warnings.
- Request-console refinements: denser operator layout (counts on titles, larger headings, sticky table header, keyboard-navigable rows, clearer Pause help, Clear enabled only after server confirmation), removed unused table headers, and the bolder jade-green selected-row color distinct from the hover highlight.
- OpenAPI stub seeding removal (rolled in from the former "Unreleased" section).
- README screenshot updates.

`README.md` — updated the `go install github.com/sspencer/mock@v0.1.1` example to `@v0.1.2` (the only `v0.1.1` string in the repo outside the changelog; `version.go` derives its version from `git describe`).

Documentation-only change; no code or behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47af5504-4421-492f-bd3d-fb12469f59c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47af5504-4421-492f-bd3d-fb12469f59c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

