### PR TITLE
Audit Astra-era master: tighten CSRF, drop leftover scaffolding

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: ["master", "astra"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer, logger *slog.
 			ready := make(chan struct{})
 			reload := func() {
 				<-ready
-				reloadMockFiles(mockServer, files, "", logger, stdout, stderr)
+				reloadMockFiles(mockServer, files, logger, stdout, stderr)
 				if err := watcher.Reconcile(resolveWatchPaths(files, mockServer.Methods())); err != nil {
 					logger.Error("failed to update dependency watches", "error", err)
 				}
@@ -249,7 +249,7 @@ type inputSource struct {
 	WatchFiles []string
 }
 
-func loadInput(args []string, stdin io.Reader, _ ...string) (inputSource, error) {
+func loadInput(args []string, stdin io.Reader) (inputSource, error) {
 	if len(args) == 1 {
 		info, err := os.Stat(args[0])
 		if err != nil {
@@ -369,7 +369,7 @@ func withCORS(next http.Handler, origin string, adminMount ...string) http.Handl
 	})
 }
 
-func reloadMockFiles(mockServer *mockhttp.Server, files []string, _ string, logger *slog.Logger, out, errOut io.Writer) {
+func reloadMockFiles(mockServer *mockhttp.Server, files []string, logger *slog.Logger, out, errOut io.Writer) {
 	mockServer.BeginReload()
 	load := func() ([]restclient.Method, error) {
 		if len(files) == 0 {

--- a/main_astra_test.go
+++ b/main_astra_test.go
@@ -57,7 +57,7 @@ func TestReloadErrorsReachDashboardState(t *testing.T) {
 	if err := os.WriteFile(path, []byte("### invalid\nNOT-A-METHOD /x"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	reloadMockFiles(server, []string{path}, "", slog.Default(), io.Discard, io.Discard)
+	reloadMockFiles(server, []string{path}, slog.Default(), io.Discard, io.Discard)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, httptest.NewRequest("GET", "/console/state", nil))
 	var state mockhttp.ConfigState
@@ -70,7 +70,7 @@ func TestReloadErrorsReachDashboardState(t *testing.T) {
 	if err := os.WriteFile(path, []byte("### fixed\nGET /x\n\ntwo"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	reloadMockFiles(server, []string{path}, "", slog.Default(), io.Discard, io.Discard)
+	reloadMockFiles(server, []string{path}, slog.Default(), io.Discard, io.Discard)
 	response = httptest.NewRecorder()
 	handler.ServeHTTP(response, httptest.NewRequest("GET", "/console/state", nil))
 	state = mockhttp.ConfigState{}

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ created
 
 func TestLoadInputUsesSingleDirectoryAsStaticRoot(t *testing.T) {
 	dir := t.TempDir()
-	input, err := loadInput([]string{dir}, strings.NewReader(""), "")
+	input, err := loadInput([]string{dir}, strings.NewReader(""))
 	if err != nil {
 		t.Fatalf("loadInput() error = %v", err)
 	}
@@ -87,7 +87,7 @@ func TestLoadInputRejectsDirectoryMixedWithRequestFiles(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	_, err := loadInput([]string{dir, path}, strings.NewReader(""), "")
+	_, err := loadInput([]string{dir, path}, strings.NewReader(""))
 	if err == nil {
 		t.Fatal("loadInput() error = nil, want error")
 	}
@@ -530,7 +530,7 @@ ok
 	server := mockhttp.New(nil, logger)
 
 	var output bytes.Buffer
-	reloadMockFiles(server, []string{path}, "", logger, &output, io.Discard)
+	reloadMockFiles(server, []string{path}, logger, &output, io.Discard)
 
 	response := httptest.NewRecorder()
 	server.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/users", nil))
@@ -569,7 +569,7 @@ ok
 
 	var output bytes.Buffer
 	var errOut bytes.Buffer
-	reloadMockFiles(server, []string{path}, "", logger, &output, &errOut)
+	reloadMockFiles(server, []string{path}, logger, &output, &errOut)
 	if output.Len() != 0 {
 		t.Fatalf("output = %q, want empty on failed reload", output.String())
 	}
@@ -704,7 +704,7 @@ func TestEndToEndReloadServesNewRoutes(t *testing.T) {
 
 	changed := make(chan struct{}, 1)
 	closer, err := watchFiles([]string{path}, func() {
-		reloadMockFiles(server, []string{path}, "", logger, io.Discard, io.Discard)
+		reloadMockFiles(server, []string{path}, logger, io.Discard, io.Discard)
 		select {
 		case changed <- struct{}{}:
 		default:

--- a/mockhttp/astra_events_test.go
+++ b/mockhttp/astra_events_test.go
@@ -1,12 +1,15 @@
 package mockhttp
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestConcurrentPublicationIsOrdered(t *testing.T) {
@@ -58,5 +61,46 @@ func TestRestartCursorAndClearBoundary(t *testing.T) {
 	event := <-ch
 	if event.Kind != "clear" || len(ch) != 0 {
 		t.Fatal("clear failed to replace queued history")
+	}
+}
+
+func TestSSESurvivesServerWriteTimeout(t *testing.T) {
+	s := New(nil, nil)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(s.ServeEvents))
+	ts.Config.WriteTimeout = 250 * time.Millisecond
+	ts.Start()
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	got := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), "/after-timeout") {
+				got <- scanner.Text()
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			got <- "err:" + err.Error()
+			return
+		}
+		got <- "eof"
+	}()
+
+	time.Sleep(400 * time.Millisecond)
+	s.publishRequest(RequestEvent{Request: EventRequest{URL: "/after-timeout"}})
+	select {
+	case msg := <-got:
+		if !strings.Contains(msg, "/after-timeout") {
+			t.Fatalf("SSE died or missed event: %s", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for SSE event after WriteTimeout window")
 	}
 }

--- a/mockhttp/astra_http_test.go
+++ b/mockhttp/astra_http_test.go
@@ -39,6 +39,12 @@ func TestClearRejectsCrossOriginEvenWithCustomHeader(t *testing.T) {
 	if !clearRequestAllowed(r) {
 		t.Fatal("same-origin clear rejected")
 	}
+	form := httptest.NewRequest("POST", "http://localhost/clear", nil)
+	form.Header.Set("Origin", "http://localhost")
+	form.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if clearRequestAllowed(form) {
+		t.Fatal("same-origin form POST accepted without X-Requested-With or JSON")
+	}
 }
 func TestClearWhileSubscriberReads(t *testing.T) {
 	s := New(nil, nil)

--- a/mockhttp/events.go
+++ b/mockhttp/events.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
-
-	"github.com/sspencer/mock/restclient"
 )
 
 const maxRequestEvents = 1000
@@ -171,8 +169,7 @@ func clearRequestAllowed(r *http.Request) bool {
 		return true
 	}
 	ct, _, _ := strings.Cut(r.Header.Get("Content-Type"), ";")
-	return strings.EqualFold(strings.TrimSpace(ct), "application/json") || site == "same-origin" || origin != ""
-
+	return strings.EqualFold(strings.TrimSpace(ct), "application/json")
 }
 
 // ServeRoutes handles GET of the currently configured mock routes.
@@ -287,15 +284,6 @@ func parseLastEventID(r *http.Request) uint64 {
 		return 0
 	}
 	return id
-}
-
-// RoutesFromMethods is a helper for tests and CLI summaries.
-func RoutesFromMethods(methods []restclient.Method) []RouteInfo {
-	routes := make([]RouteInfo, 0, len(methods))
-	for i, method := range methods {
-		routes = append(routes, describeRoute(method, i, 0))
-	}
-	return routes
 }
 
 // EventBody retains byte counts and binary data separately from display markers.

--- a/mockhttp/events_test.go
+++ b/mockhttp/events_test.go
@@ -145,6 +145,9 @@ func TestPublishRequestBoundsStoredEventsAndDropsFullSubscribers(t *testing.T) {
 	if server.events[0].ID == 0 {
 		t.Fatal("stored event missing id")
 	}
+	if _, ok := server.subscribers[subscriber]; ok {
+		t.Fatal("overflow left subscriber registered")
+	}
 }
 
 func TestSubscribeReturnsSnapshotAndUnsubscribeRemovesSubscriber(t *testing.T) {

--- a/mockhttp/match_test.go
+++ b/mockhttp/match_test.go
@@ -78,7 +78,7 @@ func formatFixture(methods []restclient.Method) (string, error) {
 			method.Method,
 			method.Path,
 			delay,
-			statusFromVariables(nil, method.Variables),
+			method.Status,
 			headerSize(responseHeaders(method, nil, filePath)),
 			len(body),
 		)

--- a/mockhttp/render.go
+++ b/mockhttp/render.go
@@ -3,7 +3,6 @@ package mockhttp
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"math/rand/v2"
 	"mime"
 	"net/http"
@@ -28,22 +27,6 @@ var fakerPool = sync.Pool{
 	},
 }
 
-func statusFromVariables(logger *slog.Logger, variables map[string]string) int {
-	raw, ok := variables["status"]
-	if !ok {
-		return http.StatusOK
-	}
-	status, err := parseStatusCode(raw)
-	if err != nil {
-		if logger == nil {
-			logger = slog.Default()
-		}
-		logger.Warn("ignoring invalid $status", "status", raw, "error", err)
-		return http.StatusOK
-	}
-	return status
-}
-
 func parseStatusCode(raw string) (int, error) {
 	status, err := strconv.Atoi(raw)
 	if err != nil {
@@ -56,7 +39,7 @@ func parseStatusCode(raw string) (int, error) {
 }
 
 func statusAllowsBody(status int) bool {
-	return status != http.StatusNoContent && status != http.StatusNotModified && (status < 200 || status >= 200)
+	return status != http.StatusNoContent && status != http.StatusNotModified
 }
 
 func responseHeaders(method restclient.Method, values map[string]string, filePath string) http.Header {

--- a/mockhttp/render_test.go
+++ b/mockhttp/render_test.go
@@ -43,6 +43,15 @@ func TestGeneratedValueSupportsDocumentedKeys(t *testing.T) {
 	}
 }
 
+func TestStatusAllowsBody(t *testing.T) {
+	if statusAllowsBody(http.StatusNoContent) || statusAllowsBody(http.StatusNotModified) {
+		t.Fatal("204 and 304 must not allow a body")
+	}
+	if !statusAllowsBody(http.StatusOK) || !statusAllowsBody(http.StatusCreated) || !statusAllowsBody(http.StatusBadRequest) {
+		t.Fatal("ordinary final statuses should allow a body")
+	}
+}
+
 func TestGeneratedValueReturnsEmptyForUnknownKey(t *testing.T) {
 	if got := generatedValue("missing"); got != "" {
 		t.Fatalf("generatedValue(missing) = %q, want empty string", got)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Audit scope

Compared current `master` (`936e28ba`, v0.1.3 docs) to the pre-Astra baseline (`857788f4` / `a46b86e6`). Everything after that merge wave is in scope: events/SSE, HAR, matching, reload/watch, admin UI `static/`, docs, CI, and deps.

This is **not** a product rewrite. The Astra wave added real, wired behavior. Most of it should stay. This PR is the small set of mistakes and leftovers I could prove, plus an honest report of what I kept and what I did not touch.

## Bugs fixed

- **CSRF on `POST /clear` and `POST /reset` was looser than the documented contract.** After Origin/scheme and `Sec-Fetch-Site` checks, Astra still allowed any same-origin `Origin` or `Sec-Fetch-Site: same-origin` without `X-Requested-With` or JSON. That contradicted the existing comment and the v0.1.2 hardening (“bare form-style POSTs are rejected”). Cross-origin was already rejected (an Astra improvement). This PR requires `X-Requested-With` or `Content-Type: application/json` after those origin checks. Dashboard fetch calls already send `X-Requested-With`.
- **`statusAllowsBody` had a tautology.** `(status < 200 || status >= 200)` is always true — leftover from a botched 1xx exclusion. Load already rejects `$status` outside 200–999. Function now just excludes 204 and 304.
- **Overflow subscribers were closed but the older test never checked that.** `TestPublishRequestBoundsStoredEventsAndDropsFullSubscribers` now asserts the subscriber is removed from the map.

## Complexity removed

- Unused `statusFromVariables` (status now lives on the compiled `Method` from `cloneMethods` / parse).
- Unused `RoutesFromMethods` helper.
- Dummy `loadInput(...string)` and `reloadMockFiles(_ string)` parameters that nothing used.
- CI `push` trigger for a leftover `astra` branch.

## Intentional keepers

I verified the “Astra over-engineered events, reload, and inspector” hypothesis and **mostly discarded it**. Those pieces are larger than v0.1.2, but they are wired, tested, and do real work:

- **SSE:** session cursors, restart/gap/clear events, overflow disconnect + replay, heartbeats, per-write deadlines. A probe with `WriteTimeout=250ms` still delivered a later event because `SetWriteDeadline` is reset before each write. Kept, with a regression test.
- **Reload/watch:** serialized callbacks, ancestor watches for missing `$file` deps, `BeginReload` / `ReloadFailed` → `/state`. Justified.
- **Inspector UI:** Pretty/Raw, copy body/cURL, route inspection, mismatch candidates, splitters, mobile back, independent clear/reset. All used. Moss/jade console identity left alone.
- **HAR:** built from captured bytes/metadata, not UI text. Real HAR 1.2 with honest timings (`send`/`receive` = -1). Kept.
- **Matching:** encoded-path matching, Host/`Content-Length` as matchable headers, path params winning over query, pointer-keyed rotation so header-distinct sequences do not share a counter. Kept.
- **Hardening that still holds:** localhost bind default, CORS preflight-only, admin paths excluded from CORS, Docker `USER nobody`, no OpenAPI revival, `$file` confined with `os.OpenRoot`.

## Residual risks

- **`FileDependencies` in `restclient` is unused by production watch code** (`resolveWatchPaths` does the real work). Left in place; it has tests and is a small public helper.
- **`/state` exposes `Loading` / `LastAttempt` / revision, but the UI only shows reload errors.** Not dead — route IDs and match metadata use revision. Loading is unused in the dashboard after the banner was removed.
- **SSE write deadline is 10s; heartbeat is 15s.** Writes reset the deadline first, so this is not a proven failure. Still a little brittle if `SetWriteDeadline` is ignored.
- **`POTENTIAL_FEATURES.md` is planning notes, not code scaffolding.** Left as-is.
- **Admin UI is still unauthenticated.** Binding `0.0.0.0` still warns. Captures and Copy cURL still include credentials (documented).
- **`*_astra_test.go` filenames** are noisy but the tests are valuable. Did not rename.

## Test results

Local and GitHub CI are green.

- `make all` / `make verify`
- `go test ./... -race -count=1`
- `node --test tests/*.test.mjs`
- GitHub Actions `Go / build` on this branch succeeded

Do not merge. Treat this body as the audit report.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22409fa6-61f3-429d-b200-2af3dbef1add?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22409fa6-61f3-429d-b200-2af3dbef1add&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

