### PR TITLE
Document v0.1.4 changelog and bump README install pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.4 - 2026-09-06
+
+Audit cleanup after v0.1.3: tighter admin CSRF checks and small correctness/housekeeping fixes.
+
+- Tighten CSRF checks on admin clear/reset (`POST /mock/clear`, `POST /mock/reset`)
+- Fix a tautological `statusAllowsBody` check
+- Remove dead helpers / leftover scaffolding and the unused `astra` CI branch reference
+
 ## v0.1.3 - 2026-09-06
 
 Expanded request inspection, more reliable traffic capture and reloads, and

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prism, or Mockoon, and not the Go unit-test mocking libraries (gomock, mockery).
 Requires [Go](https://go.dev/dl/) 1.26 or newer:
 
 ```sh
-go install github.com/sspencer/mock@v0.1.3
+go install github.com/sspencer/mock@v0.1.4
 mock -version
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only release notes for v0.1.4. CoS will tag `v0.1.4` after merge.

This covers the audit squash `248d3e06` / PR #14 ("Audit Astra-era master: tighten CSRF, drop leftover scaffolding").

## Changes

- Add a `v0.1.4` section to `CHANGELOG.md` immediately after the heading. The `v0.1.3` and older sections are unchanged.
- Pin the README install command to `go install github.com/sspencer/mock@v0.1.4`.

No code, tag, or product-feature changes. This release documents audit cleanup after v0.1.3 only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3399c79d-7f71-4efa-bd88-ac66960e2bec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3399c79d-7f71-4efa-bd88-ac66960e2bec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

